### PR TITLE
feat(protein): add AlphaFold structure viewer and AlphaMissense panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -5566,10 +5566,12 @@ async function loadProteinStructure(moduleState) {
 
     if (moduleState.modelUrl !== state.proteinViewerModelUrl) {
       await viewer.loadStructureFromUrl(moduleState.modelUrl, 'mmcif', false);
+      if (requestId !== state.proteinViewerRequestId) return;
       state.proteinViewerModelUrl = moduleState.modelUrl;
+    } else if (requestId !== state.proteinViewerRequestId) {
+      return;
     }
 
-    if (requestId !== state.proteinViewerRequestId) return;
     if (moduleState.residue) {
       statusHost.textContent = `Loaded ${moduleState.alphafoldEntry}. Residue ${moduleState.residue} is selected in metadata panel.`;
     } else {
@@ -5628,6 +5630,7 @@ async function renderProteinModule() {
 
   const moduleState = buildProteinModuleState();
   state.proteinModuleState = moduleState;
+  state.proteinViewerRequestId += 1;
   renderProteinMetadata(moduleState);
   clearProteinViewerForStatus(moduleState.status);
 

--- a/app.js
+++ b/app.js
@@ -1,3 +1,10 @@
+const ENABLE_PROTEIN_MODULE = true;
+const ALPHAMISSENSE_THRESHOLDS = {
+  likelyPathogenic: 0.564,
+  likelyBenign: 0.34
+};
+const PROTEIN_RENDER_DEBOUNCE_MS = 120;
+
 const FALLBACK_DATA = {
   "genes": {
     "totalCount": 60,
@@ -4436,6 +4443,11 @@ const state = {
   nav: 'home',
   geneQuery: '',
   data: {},
+  proteinModuleState: { status: 'idle' },
+  proteinViewer: null,
+  proteinViewerModelUrl: null,
+  proteinViewerRequestId: 0,
+  proteinRenderTimer: null,
   igvBrowser: null,
   igvBrowserRequestId: 0,
   igvBrowserReady: false,
@@ -4457,7 +4469,8 @@ const DATA_MAP = {
   family: 'data/family.json',
   cohort: 'data/cohort.json',
   predictions: 'data/predictions.json',
-  igv: 'data/igv.json'
+  igv: 'data/igv.json',
+  proteinAnnotations: 'data/protein_annotations.json'
 };
 
 const RESPONSIVE_TABLES = {
@@ -4511,6 +4524,7 @@ async function boot() {
   wireSearch();
   wirePills();
   wirePredictionTabs();
+  wireProteinModuleControls();
   renderAll();
   syncResponsivePageSizes();
   window.addEventListener('resize', handleResponsiveResize, { passive: true });
@@ -4523,6 +4537,7 @@ function renderAll() {
   renderVariantTable();
   renderPhenotypePanel();
   renderPredictionTab();
+  queueProteinModuleRender();
 }
 
 function paginateRows(rows, page, pageSize) {
@@ -4716,6 +4731,7 @@ function renderGeneTable() {
       if (hasActiveTextSelection()) return;
       state.selectedGeneRow = pageRows[parseInt(tr.dataset.rowIndex, 10)];
       renderGeneTable();
+      queueProteinModuleRender();
     });
   });
 
@@ -4756,6 +4772,7 @@ function renderVariantTable() {
       state.selectedVariantRow = pageRows[parseInt(tr.dataset.rowIndex, 10)];
       renderVariantTable();
       renderPredictionTab();
+      queueProteinModuleRender();
     });
   });
 
@@ -4767,6 +4784,7 @@ function renderVariantTable() {
     if (scroller) scroller.scrollTop = 0;
     renderVariantTable();
     renderPredictionTab();
+    queueProteinModuleRender();
   });
   requestAnimationFrame(() => updateTableScrollControls('variants'));
 }
@@ -5432,6 +5450,199 @@ function renderPredictionTab() {
       </ul>
     `;
   }
+}
+
+function getProteinAnnotationsForGene(geneSymbol) {
+  const annotations = state.data.proteinAnnotations || {};
+  if (!geneSymbol) return null;
+  return annotations[geneSymbol] || null;
+}
+
+function isMissenseVariant(variantRow) {
+  return String(variantRow?.effect || '').toLowerCase().includes('missense');
+}
+
+function deriveAlphaMissenseClass(score) {
+  if (!Number.isFinite(score)) return null;
+  if (score >= ALPHAMISSENSE_THRESHOLDS.likelyPathogenic) return 'likely_pathogenic';
+  if (score <= ALPHAMISSENSE_THRESHOLDS.likelyBenign) return 'likely_benign';
+  return 'ambiguous';
+}
+
+function buildProteinModuleState() {
+  const selectedGene = state.selectedGeneRow;
+  const selectedVariant = state.selectedVariantRow;
+
+  if (!selectedGene) return { status: 'no_gene' };
+  if (!selectedVariant) return { status: 'no_variant', gene: selectedGene.gene };
+  if (!isMissenseVariant(selectedVariant)) {
+    return { status: 'non_missense', gene: selectedGene.gene, variant: selectedVariant };
+  }
+
+  const geneEntry = getProteinAnnotationsForGene(selectedGene.gene);
+  if (!geneEntry?.alphafold?.modelUrl) {
+    return { status: 'missing_structure', gene: selectedGene.gene, variant: selectedVariant };
+  }
+
+  const variantEntry = geneEntry.variants?.[selectedVariant.variant];
+  const baseState = {
+    status: 'missing_alphamissense',
+    gene: selectedGene.gene,
+    variant: selectedVariant,
+    modelUrl: geneEntry.alphafold.modelUrl,
+    alphafoldEntry: geneEntry.alphafold.entryId,
+    alphafoldUrl: geneEntry.alphafold.entryUrl || `https://alphafold.ebi.ac.uk/entry/${geneEntry.alphafold.entryId}`,
+    proteinChange: variantEntry?.proteinChange || 'Not provided',
+    transcript: variantEntry?.transcript || selectedVariant.transcript || 'Unknown',
+    residue: variantEntry?.proteinPosition ?? null,
+    score: variantEntry?.alphamissense?.score ?? null,
+    classification: variantEntry?.alphamissense?.class || null
+  };
+
+  if (!Number.isFinite(baseState.score)) return baseState;
+  return {
+    ...baseState,
+    status: 'ready',
+    classification: baseState.classification || deriveAlphaMissenseClass(baseState.score)
+  };
+}
+
+function getProteinStatusCopy(moduleState) {
+  const statusMap = {
+    no_gene: 'Select a gene to enable protein context.',
+    no_variant: 'Select a variant to load AlphaFold and AlphaMissense context.',
+    non_missense: 'AlphaMissense is available for missense substitutions only.',
+    missing_structure: 'AlphaFold structure unavailable for this gene in the local annotation set.',
+    missing_alphamissense: 'Structure is available, but AlphaMissense score is unavailable for this missense variant.',
+    ready: 'Protein structure and AlphaMissense prediction loaded.'
+  };
+  return statusMap[moduleState.status] || 'Protein module is waiting for a valid selection.';
+}
+
+function formatClassificationLabel(classification) {
+  if (!classification) return 'Unavailable';
+  return classification.replaceAll('_', ' ');
+}
+
+function queueProteinModuleRender() {
+  if (!ENABLE_PROTEIN_MODULE) return;
+  if (state.proteinRenderTimer) window.clearTimeout(state.proteinRenderTimer);
+  state.proteinRenderTimer = window.setTimeout(() => {
+    state.proteinRenderTimer = null;
+    renderProteinModule();
+  }, PROTEIN_RENDER_DEBOUNCE_MS);
+}
+
+async function getOrCreateProteinViewer() {
+  if (state.proteinViewer) return state.proteinViewer;
+  if (!window.molstar?.Viewer?.create) return null;
+  const viewer = await window.molstar.Viewer.create('protein-viewer', {
+    layoutShowControls: false,
+    layoutShowLeftPanel: false,
+    layoutShowSequence: false,
+    layoutShowLog: false,
+    viewportShowExpand: false
+  });
+  state.proteinViewer = viewer;
+  return viewer;
+}
+
+async function loadProteinStructure(moduleState) {
+  const statusHost = document.querySelector('#protein-module-status');
+  const retryBtn = document.querySelector('#protein-retry-btn');
+  if (!moduleState?.modelUrl) return;
+
+  const requestId = state.proteinViewerRequestId + 1;
+  state.proteinViewerRequestId = requestId;
+  statusHost.textContent = `Loading AlphaFold model ${moduleState.alphafoldEntry || ''}...`;
+  retryBtn?.classList.add('is-hidden');
+
+  try {
+    const viewer = await getOrCreateProteinViewer();
+    if (!viewer) {
+      statusHost.textContent = 'Mol* did not load. Check network access and reload.';
+      return;
+    }
+
+    if (moduleState.modelUrl !== state.proteinViewerModelUrl) {
+      await viewer.loadStructureFromUrl(moduleState.modelUrl, 'mmcif', false);
+      state.proteinViewerModelUrl = moduleState.modelUrl;
+    }
+
+    if (requestId !== state.proteinViewerRequestId) return;
+    if (moduleState.residue) {
+      statusHost.textContent = `Loaded ${moduleState.alphafoldEntry}. Residue ${moduleState.residue} is selected in metadata panel.`;
+    } else {
+      statusHost.textContent = `Loaded ${moduleState.alphafoldEntry}.`;
+    }
+  } catch (error) {
+    if (requestId !== state.proteinViewerRequestId) return;
+    statusHost.textContent = `Failed to load AlphaFold structure: ${error?.message || 'Unknown error'}`;
+    retryBtn?.classList.remove('is-hidden');
+    console.error(error);
+  }
+}
+
+function renderProteinMetadata(moduleState) {
+  const statusHost = document.querySelector('#protein-module-status');
+  const noteHost = document.querySelector('#protein-module-note');
+  const geneHost = document.querySelector('#protein-gene');
+  const changeHost = document.querySelector('#protein-change');
+  const transcriptHost = document.querySelector('#protein-transcript');
+  const residueHost = document.querySelector('#protein-residue');
+  const scoreHost = document.querySelector('#protein-score');
+  const classHost = document.querySelector('#protein-class');
+  const alphaFoldLink = document.querySelector('#protein-alphafold-link');
+
+  statusHost.textContent = getProteinStatusCopy(moduleState);
+  geneHost.textContent = moduleState.gene || '-';
+  changeHost.textContent = moduleState.proteinChange || moduleState.variant?.hgvsc || '-';
+  transcriptHost.textContent = moduleState.transcript || moduleState.variant?.transcript || '-';
+  residueHost.textContent = Number.isFinite(moduleState.residue) ? String(moduleState.residue) : '-';
+  scoreHost.textContent = Number.isFinite(moduleState.score) ? moduleState.score.toFixed(3) : 'Unavailable';
+  classHost.textContent = formatClassificationLabel(moduleState.classification);
+  classHost.className = `protein-class-badge ${moduleState.classification || 'neutral'}`;
+  noteHost.textContent = 'AlphaMissense is predictive evidence and should not be used as standalone clinical evidence.';
+
+  if (moduleState.alphafoldUrl) {
+    alphaFoldLink.href = moduleState.alphafoldUrl;
+    alphaFoldLink.setAttribute('aria-disabled', 'false');
+  } else {
+    alphaFoldLink.href = '#';
+    alphaFoldLink.setAttribute('aria-disabled', 'true');
+  }
+}
+
+function clearProteinViewerForStatus(status) {
+  const viewerHost = document.querySelector('#protein-viewer');
+  if (!viewerHost) return;
+  if (status === 'ready' || status === 'missing_alphamissense') return;
+  viewerHost.innerHTML = '<div class=\"protein-viewer-empty\">No structure loaded for this selection.</div>';
+  state.proteinViewerModelUrl = null;
+}
+
+async function renderProteinModule() {
+  if (!ENABLE_PROTEIN_MODULE) return;
+  const moduleCard = document.querySelector('.protein-module-card');
+  if (!moduleCard) return;
+
+  const moduleState = buildProteinModuleState();
+  state.proteinModuleState = moduleState;
+  renderProteinMetadata(moduleState);
+  clearProteinViewerForStatus(moduleState.status);
+
+  if (moduleState.status === 'ready' || moduleState.status === 'missing_alphamissense') {
+    await loadProteinStructure(moduleState);
+  }
+}
+
+function wireProteinModuleControls() {
+  const retryBtn = document.querySelector('#protein-retry-btn');
+  if (!retryBtn || retryBtn.dataset.wired === 'true') return;
+  retryBtn.dataset.wired = 'true';
+  retryBtn.addEventListener('click', () => {
+    queueProteinModuleRender();
+  });
 }
 
 function wireSearch() {

--- a/app.js
+++ b/app.js
@@ -5547,6 +5547,20 @@ async function getOrCreateProteinViewer() {
   return viewer;
 }
 
+function disposeProteinViewer() {
+  if (!state.proteinViewer) return;
+  try {
+    if (typeof state.proteinViewer.dispose === 'function') {
+      state.proteinViewer.dispose();
+    }
+  } catch (error) {
+    console.warn('Failed to dispose Mol* viewer instance cleanly.', error);
+  } finally {
+    state.proteinViewer = null;
+    state.proteinViewerModelUrl = null;
+  }
+}
+
 async function loadProteinStructure(moduleState) {
   const statusHost = document.querySelector('#protein-module-status');
   const retryBtn = document.querySelector('#protein-retry-btn');
@@ -5619,8 +5633,8 @@ function clearProteinViewerForStatus(status) {
   const viewerHost = document.querySelector('#protein-viewer');
   if (!viewerHost) return;
   if (status === 'ready' || status === 'missing_alphamissense') return;
+  disposeProteinViewer();
   viewerHost.innerHTML = '<div class=\"protein-viewer-empty\">No structure loaded for this selection.</div>';
-  state.proteinViewerModelUrl = null;
 }
 
 async function renderProteinModule() {

--- a/data/protein_annotations.json
+++ b/data/protein_annotations.json
@@ -1,0 +1,62 @@
+{
+  "MECP2": {
+    "uniprot": "P51608",
+    "alphafold": {
+      "entryId": "AF-P51608-F1",
+      "entryUrl": "https://alphafold.ebi.ac.uk/entry/P51608",
+      "modelUrl": "https://alphafold.ebi.ac.uk/files/AF-P51608-F1-model_v4.cif"
+    },
+    "variants": {
+      "2-104856069-T-TG": {
+        "proteinChange": "p.Arg106Trp",
+        "transcript": "NM_001110792.2",
+        "proteinPosition": 106,
+        "refAa": "R",
+        "altAa": "W",
+        "alphamissense": {
+          "score": 0.93,
+          "class": "likely_pathogenic",
+          "source": "AlphaMissense precomputed"
+        }
+      },
+      "2-104856291-C-A": {
+        "proteinChange": "p.Arg113His",
+        "transcript": "NM_001110792.2",
+        "proteinPosition": 113,
+        "refAa": "R",
+        "altAa": "H",
+        "alphamissense": {
+          "score": 0.24,
+          "class": "likely_benign",
+          "source": "AlphaMissense precomputed"
+        }
+      }
+    }
+  },
+  "TXNIP": {
+    "uniprot": "Q9H3M7",
+    "alphafold": {
+      "entryId": "AF-Q9H3M7-F1",
+      "entryUrl": "https://alphafold.ebi.ac.uk/entry/Q9H3M7",
+      "modelUrl": "https://alphafold.ebi.ac.uk/files/AF-Q9H3M7-F1-model_v4.cif"
+    },
+    "variants": {
+      "16-104856476-C-A": {
+        "proteinChange": "p.Leu188Met",
+        "transcript": "NM_006472.6",
+        "proteinPosition": 188,
+        "refAa": "L",
+        "altAa": "M"
+      }
+    }
+  },
+  "SHANK3": {
+    "uniprot": "Q9BYB0",
+    "alphafold": {
+      "entryId": "",
+      "entryUrl": "",
+      "modelUrl": ""
+    },
+    "variants": {}
+  }
+}

--- a/index.html
+++ b/index.html
@@ -196,6 +196,32 @@
 
         </div>
 
+
+        <article class="card protein-module-card" aria-labelledby="protein-module-title">
+          <div class="protein-module-head">
+            <div id="protein-module-title" class="card-title">PROTEIN STRUCTURE &amp; ALPHAMISSENSE</div>
+            <div id="protein-module-status" class="protein-module-status" role="status" aria-live="polite"></div>
+          </div>
+          <div class="protein-module-body">
+            <div id="protein-viewer" class="protein-viewer" tabindex="0" aria-label="Protein structure viewer"></div>
+            <div class="protein-side-panel">
+              <dl class="protein-metadata-list">
+                <div><dt>Gene</dt><dd id="protein-gene">-</dd></div>
+                <div><dt>Protein change</dt><dd id="protein-change">-</dd></div>
+                <div><dt>Transcript</dt><dd id="protein-transcript">-</dd></div>
+                <div><dt>Residue</dt><dd id="protein-residue">-</dd></div>
+                <div><dt>AlphaMissense score</dt><dd id="protein-score">-</dd></div>
+                <div><dt>Classification</dt><dd><span id="protein-class" class="protein-class-badge neutral">Unavailable</span></dd></div>
+              </dl>
+              <p id="protein-module-note" class="protein-module-note"></p>
+              <div class="protein-links">
+                <a id="protein-alphafold-link" href="#" target="_blank" rel="noreferrer">AlphaFold entry</a>
+                <a id="protein-alphamissense-link" href="https://github.com/google-deepmind/alphamissense" target="_blank" rel="noreferrer">AlphaMissense source</a>
+              </div>
+              <button id="protein-retry-btn" type="button" class="tab-action-btn protein-retry-btn is-hidden">Retry structure load</button>
+            </div>
+          </div>
+        </article>
         <article class="card predictions-card">
           <div class="predictions-wrap">
             <div class="predictions-head">
@@ -210,6 +236,8 @@
     </section>
   </main>
 
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar@4.8.0/build/viewer/molstar.css">
+  <script src="https://cdn.jsdelivr.net/npm/molstar@4.8.0/build/viewer/molstar.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/igv@3.0.0/dist/igv.min.js"></script>
   <script src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1188,3 +1188,120 @@ th.section-title{
   overflow:hidden;
   background:#fff;
 }
+
+.protein-module-card{
+  min-height:360px;
+  display:flex;
+  flex-direction:column;
+}
+.protein-module-head{
+  padding:14px 14px 10px;
+  border-bottom:1px solid #efeff2;
+}
+.protein-module-status{
+  font-size:12px;
+  color:#667085;
+}
+.protein-module-body{
+  display:grid;
+  grid-template-columns:minmax(0, 1fr) minmax(220px, .42fr);
+  gap:12px;
+  padding:12px 14px 14px;
+  min-height:0;
+  flex:1;
+}
+.protein-viewer{
+  min-height:300px;
+  border:1px solid var(--border);
+  border-radius:10px;
+  overflow:hidden;
+  background:#fbfcff;
+}
+.protein-viewer:focus-visible,
+.protein-links a:focus-visible{
+  outline:2px solid #3557d5;
+  outline-offset:2px;
+}
+.protein-viewer-empty{
+  width:100%;
+  height:100%;
+  min-height:300px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:#7a8291;
+  font-size:12px;
+}
+.protein-side-panel{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.protein-metadata-list{
+  margin:0;
+  display:grid;
+  gap:8px;
+}
+.protein-metadata-list div{
+  display:flex;
+  justify-content:space-between;
+  gap:8px;
+  align-items:flex-start;
+}
+.protein-metadata-list dt{
+  margin:0;
+  font-size:10px;
+  color:#8a909b;
+  text-transform:uppercase;
+  letter-spacing:.03em;
+}
+.protein-metadata-list dd{
+  margin:0;
+  font-size:12px;
+  color:#323744;
+  text-align:right;
+}
+.protein-class-badge{
+  display:inline-flex;
+  align-items:center;
+  border-radius:999px;
+  padding:2px 8px;
+  font-size:10px;
+  font-weight:700;
+  text-transform:uppercase;
+}
+.protein-class-badge.likely_pathogenic{background:#ffe8ea;color:#c2374e;}
+.protein-class-badge.likely_benign{background:#e8f0ff;color:#3557d5;}
+.protein-class-badge.ambiguous{background:#fff1d8;color:#ad7f20;}
+.protein-class-badge.neutral{background:#eef1f4;color:#68717d;}
+.protein-module-note{
+  margin:0;
+  color:#7a8291;
+  font-size:11px;
+  line-height:1.45;
+}
+.protein-links{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+.protein-links a{
+  color:#3557d5;
+  font-size:11px;
+  text-decoration:none;
+}
+.protein-links a[aria-disabled="true"]{
+  color:#9ba0ab;
+  pointer-events:none;
+}
+.protein-retry-btn{
+  width:max-content;
+}
+.is-hidden{
+  display:none !important;
+}
+@media (max-width: 1440px){
+  .protein-module-body{
+    grid-template-columns:1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide structural context and AlphaMissense predictions for selected gene/variant in the right-column prediction area to aid variant interpretation.
- Use a deterministic front-end data contract so the UI can render AlphaFold CIF models and precomputed AlphaMissense scores without additional API hops.

### Description
- Added a new `PROTEIN STRUCTURE & ALPHAMISSENSE` card to `index.html` with a Mol* viewer host, metadata side panel, provenance links, status text, and retry control.
- Integrated Mol* via CDN by adding Mol* CSS/JS to `index.html` and implemented viewer lifecycle in `app.js` using `getOrCreateProteinViewer()` and `loadStructureFromUrl()` to load CIF models.
- Introduced feature flags and config constants (`ENABLE_PROTEIN_MODULE`, `ALPHAMISSENSE_THRESHOLDS`, `PROTEIN_RENDER_DEBOUNCE_MS`) and new app state fields for the protein viewer and debounce (`proteinModuleState`, `proteinViewer`, `proteinViewerModelUrl`, `proteinViewerRequestId`, `proteinRenderTimer`).
- Implemented annotation plumbing and resolution in `app.js`: load `data/protein_annotations.json` via `DATA_MAP`, `buildProteinModuleState()` for status enums (`no_gene`, `no_variant`, `non_missense`, `missing_structure`, `missing_alphamissense`, `ready`), AlphaMissense class derivation, debounced rendering (`queueProteinModuleRender()`), metadata rendering, retry wiring, and non-blocking error handling.
- Hooked the protein module refresh into existing selection flows so changes to gene/variant rows call `queueProteinModuleRender()` without altering IGV or prediction behavior.
- Added responsive and accessible styling in `styles.css` for the module (split layout on desktop, stacked on smaller screens) and badge color states for `likely_benign` / `ambiguous` / `likely_pathogenic`.
- Added seeded `data/protein_annotations.json` with example AlphaFold entries and per-variant AlphaMissense scores for demo/testing.

### Testing
- Ran `node --check app.js` to validate JS syntax; the check succeeded.
- Validated `data/protein_annotations.json` with `python -m json.tool data/protein_annotations.json >/dev/null`; validation succeeded.
- Ran `git diff --check` to surface whitespace/conflict issues; it returned clean.
- Changes committed under message `feat(protein): add AlphaFold viewer with AlphaMissense module`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c47a5fd898832f8722f7b5d5025deb)